### PR TITLE
Add code-highlighting with shiki

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -65,7 +65,7 @@ const config = {
     },
     prism: {
       theme: prismThemes.github,
-      darkTheme: prismThemes.dracula,
+      darkTheme: prismThemes.oneDark,
     },
   },
   stylesheets: [

--- a/src/prism-languages/prism-typst-code.js
+++ b/src/prism-languages/prism-typst-code.js
@@ -1,0 +1,51 @@
+Prism.languages["typst-code"] = {
+  comment: [
+    {
+      pattern: /\/\*[\s\S]*?\*\//,
+      greedy: true,
+    },
+    {
+      pattern: /(^|[^:])\/\/.*/,
+      lookbehind: true,
+      greedy: true,
+    },
+  ],
+  string: [
+    {
+      pattern: /"(?:\\.|[^\\"])*"/,
+      greedy: true,
+    },
+    {
+      pattern: /\$(?:\\.|[^\\$])*\$/,
+      greedy: true,
+    },
+  ],
+  keyword:
+    /\b(?:as|break|context|continue|else|export|for|if|import|in|include|let|return|set|show|while)(?!-)\b/,
+  function: /\b[a-zA-Z_][\w-]*(?=\[|\()/,
+  operator:
+    /=>|\.{2}|==|!=|<=|>=|<|>|\+=|-=|\*=|\/=|=|\+|\*|\/|-|\b(?:and|not|or)\b/,
+  property: /\b[a-zA-Z_][\w-]*(?=:)/,
+  boolean: /\b(?:false|none|true)(?!-)\b/,
+  constant: [
+    {
+      pattern: /\bauto(?!-)\b/,
+    },
+    {
+      pattern: /\b\d+(\.\d+)?(?:cm|deg|em|fr|in|mm|pt|rad|%)(?!-)\b/,
+      greedy: true,
+    },
+    {
+      pattern: /\b0x[\da-fA-F]+|\b0b[01]+|\b0o[0-7]+|\b\d+\b/,
+      greedy: true,
+    },
+  ],
+  punctuation: [
+    {
+      pattern: /[{}[\];(),.:]/,
+      greedy: true,
+    },
+  ],
+};
+
+Prism.languages.typc = Prism.languages["typst-code"];

--- a/src/prism-languages/prism-typst.js
+++ b/src/prism-languages/prism-typst.js
@@ -1,0 +1,81 @@
+Prism.languages.typst = {
+  comment: [
+    {
+      pattern: /\/\*[\s\S]*?\*\//,
+      greedy: true,
+    },
+    {
+      pattern: /(^|[^:])\/\/.*/,
+      lookbehind: true,
+      greedy: true,
+    },
+  ],
+  string: [
+    {
+      pattern: /"(?:\\.|[^\\"])*"/,
+      greedy: true,
+    },
+    {
+      pattern: /\$(?:\\.|[^\\$])*\$/,
+      greedy: true,
+    },
+  ],
+  keyword:
+    /#(?:as|break|context|continue|else|export|for|if|import|in|include|let|return|set|show|while)\b/,
+  operator: {
+    pattern:
+      /=>|\.{2}|==|!=|<=|>=|<|>|\+=|-=|\*=|\/=|=|\+|\*|\/|-|\b(?:and|not|or)\b/,
+    greedy: true,
+  },
+  constant: [
+    {
+      pattern: /\b(?:auto|false|none|true)\b/,
+      greedy: true,
+    },
+    {
+      pattern: /\b\d+(\.\d+)?(?:cm|deg|em|fr|in|mm|pt|rad|%)\b/,
+      greedy: true,
+    },
+    {
+      pattern: /\b0x[\da-fA-F]+|\b0b[01]+|\b0o[0-7]+|\b\d+\b/,
+      greedy: true,
+    },
+  ],
+  punctuation: {
+    pattern: /[{}[\];(),.:]/,
+    greedy: true,
+  },
+  "attr-name": {
+    pattern: /<\w[\w-]*>/,
+    greedy: true,
+  },
+  "attr-value": {
+    pattern: /@\w[\w-]*/,
+    greedy: true,
+  },
+  bold: {
+    pattern: /\*(?=\S)(?:\\.|[^\\*])*\*(?=\W|_|$)/,
+    lookbehind: true,
+    greedy: true,
+    inside: {
+      punctuation: /\*/,
+    },
+  },
+  italic: {
+    pattern: /_(?=\S)(?:\\.|[^\\_])*_(?=\W|_|$)/,
+    lookbehind: true,
+    greedy: true,
+    inside: {
+      punctuation: /_/,
+    },
+  },
+  important: {
+    pattern: /^=+\s+[^\n<]*/,
+    greedy: true,
+    inside: {
+      punctuation: /^=+/,
+    },
+  },
+};
+
+Prism.languages.typ = Prism.languages.typst;

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -1,0 +1,25 @@
+import siteConfig from "@generated/docusaurus.config";
+
+export default function prismIncludeLanguages(PrismObject) {
+  const {
+    themeConfig: { prism },
+  } = siteConfig;
+  const { additionalLanguages } = prism;
+  // Prism components work on the Prism instance on the window, while prism-
+  // react-renderer uses its own Prism instance. We temporarily mount the
+  // instance onto window, import components to enhance it, then remove it to
+  // avoid polluting global namespace.
+  // You can mutate PrismObject: registering plugins, deleting languages... As
+  // long as you don't re-assign it
+  globalThis.Prism = PrismObject;
+  additionalLanguages.forEach((lang) => {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    require(`prismjs/components/prism-${lang}`);
+  });
+
+  // eslint-disable-next-line global-require
+  require("@site/src/prism-languages/prism-typst");
+  require("@site/src/prism-languages/prism-typst-code");
+
+  delete globalThis.Prism;
+}


### PR DESCRIPTION
This PR adds basic code highlighting by providing two Prism language definitions - one for Typst and one for Typst Code/Scripts. Both are really basic, but they should fit for the examples. I've changed the default dark theme to `oneDark`, because it's the only decent one that also highlights `parameter`s.

<details><summary>Preview</summary>

![firefox_2024-05-26_14-16-14](https://github.com/cetz-package/docs/assets/19953266/450158ea-e2e3-4115-b95a-fe3a216da76e)
![firefox_2024-05-26_14-16-22](https://github.com/cetz-package/docs/assets/19953266/7274e71c-bba4-486c-9121-0522fec887f1)

</details> 