### PR TITLE
clarify meaning of canvas({...}) syntax

### DIFF
--- a/docs/basics/canvas.md
+++ b/docs/basics/canvas.md
@@ -3,16 +3,14 @@ title: The Canvas
 sidebar_position: 1
 ---
 
-The `canvas` function is what handles all of the logic and processing in order to produce drawings.
-
-To use it, call the function like any other except place a pair of curly braces `{}` inside the brackets with a new line, these braces are now the *body* of the canvas. Then import all the draw functions you need at the top of the body.
+The `canvas` function is what handles all of the logic and processing in order to produce drawings. It's usually called with a code block `{...}` as argument. The content of the curly braces is the *body* of the canvas. Import all the draw functions you need at the top of the body:
 ```typ
 #cetz.canvas({
   import cetz.draw: *
   
 })
 ```
-You can now call the draw functions within the body and they'll produce some graphics!
+You can now call the draw functions within the body and they'll produce some graphics! Typst will evaluate the code block and pass the result to the `canvas` function for rendering.
 
 The canvas does not have typical `width` and `height` parameters. Instead its size will grow and shrink to fit the drawn graphic.
 


### PR DESCRIPTION
This rewords a bit the description of the canvas call syntax.

I was confused when I first read the doc, especially the part "call the function like any other except place a pair of curly braces `{}` inside the brackets". I was not sure what was happening when, and what I could do or could not do. I understand that this should be described in details in the upcoming "internals" section, but I think making things a bit less magical and more concrete here can help the reader get the right idea...