### PR TITLE
cetz: Update cached dep

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           cache-dependency-path: dependencies.typ
 
+      - name: Fetching cetz dependencies
+        run: typst c dependencies.typ
+
       - name: Generate api pages
         run: node scripts/generate-api.js
 

--- a/dependencies.typ
+++ b/dependencies.typ
@@ -1,1 +1,1 @@
-#import "@preview/cetz:0.2.2"
+#import "@preview/cetz:0.3.2"


### PR DESCRIPTION
Make sure dependencies are downloaded. The typst-community GH action fails to do so.